### PR TITLE
Add optional author links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,4 +28,4 @@ ignoreFiles = ["\\.sh$"]
 
 # choose a background color from any on this page: http://tachyons.io/docs/themes/skins/ and preface it with "bg-"
   background_color_class = "bg-black"
-  custom_css = ["css/hids.css","css/rouge-highlight.css"]
+  custom_css = ["css/hids.css"]

--- a/content/blog/the-upside-of-going-serverless.md
+++ b/content/blog/the-upside-of-going-serverless.md
@@ -1,6 +1,7 @@
 ---
 title: "The Upside of Going Serverless"
 author: "Paul Roub"
+author-url: https://roub.net/
 date: 2019-10-15
 ---
 
@@ -10,7 +11,7 @@ I'm here to suggest that serverless is different, and that you listen to the dev
 
 Serverless is just as much a financial change as it is technical;  the innovation is that you only pay for what you use, and the bits that aren’t directly relevant to solving your business problem are outsourced to your cloud provider.  This results in significant savings — in both upkeep and operational costs, as well as the cost of development and deployment.
 
-Over the past few years, we’ve helped clients migrate from more traditional infrastructure to serverless, and we’ve seen some great wins; this post outlines a few of our experiences.  
+Over the past few years, we’ve helped clients migrate from more traditional infrastructure to serverless, and we’ve seen some great wins; this post outlines a few of our experiences.
 
 
 ## One Example
@@ -48,7 +49,7 @@ The function apps — also backed up, tied in to Azure, etc. — scale o
 
 ## Development and Deployment
 
-In both cases, we're writing and testing locally, using TDD and BDD tools along the way. 
+In both cases, we're writing and testing locally, using TDD and BDD tools along the way.
 
 But the deployment story is different: on the older system, there are firewalls to configure; in some cases, URLs to expose (along with the associated DNS updates), and so on.
 
@@ -56,7 +57,7 @@ We deploy the newer functions to Azure, and immediately have a known, consistent
 
 You don’t _have_ to run multiple services on a single VM, but it’s extremely common to do so. Why? Cost and utilization. You’re paying a fixed amount (or at least a minimum) for that server and its capacity, whether you’re using it or not. This creates a strong incentive to use as much of that capacity as you can, and maximize ROI. Now you have a variety of services with different, sometimes conflicting requirements, all of which must be balanced against each other and against the requirements of the host operating system (which must, itself, be updated and maintained, possibly affecting one or more services running on the machine).
 
-In the serverless world, the incentives run the other way -- each instance is simple, self-contained, and has few to no inherent conflicts. 
+In the serverless world, the incentives run the other way -- each instance is simple, self-contained, and has few to no inherent conflicts.
 
 
 ## Nothing to see here

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -12,7 +12,14 @@
         {{- .Title -}}
       </h1>
       {{ if isset .Params "author" }}
-        <p class=author-credit>by {{ index .Params "author" }}</p>
+
+        <p class=author-credit>by
+          {{ if isset .Params "author-url" }}
+            <a href="{{ index .Params "author-url" }}">{{ index .Params "author" }}</a>
+          {{ else }}
+            {{ index .Params "author" }}
+          {{ end }}
+        </p>
       {{ end }}
       {{/* Hugo uses Go's date formatting is set by example. Here are two formats */}}
       <time class="f6 mv4 dib tracked" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">

--- a/static/css/hids.css
+++ b/static/css/hids.css
@@ -7,6 +7,20 @@
   margin: 0 0 .25em;
 }
 
+.author-credit a,
+.author-credit a:link,
+.author-credit a:visited,
+.author-credit a:active {
+  text-decoration: none;
+  color: inherit;
+  font-weight: 600;
+}
+
+.author-credit a:hover {
+  text-decoration: underline;
+  text-decoration-color: #00F;
+}
+
 .collage {
   max-width: 915px;
   margin: 0 auto;
@@ -39,7 +53,7 @@
   body {
     padding-bottom: 100px;
   }
-  
+
   footer {
     position: fixed;
     bottom: 0;

--- a/static/css/hids.css
+++ b/static/css/hids.css
@@ -11,9 +11,9 @@
 .author-credit a:link,
 .author-credit a:visited,
 .author-credit a:active {
-  text-decoration: none;
   color: inherit;
   font-weight: 600;
+  text-decoration: none;
 }
 
 .author-credit a:hover {


### PR DESCRIPTION
If you add an `author-url: http://whatever` line to your posts's front matter, the byline (if any) will link to that page. Added this as an example in my serverless post.